### PR TITLE
In memory without temporary file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 dependencies = [
  "block-cipher-trait",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "opaque-debug",
 ]
 
@@ -125,7 +125,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "c1fac9013995170a2953580d848223dffe1d1db93dbdcde1dd8717286e1d3934"
 dependencies = [
  "bit-vec",
  "blake2s_simd",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "crossbeam",
  "ff",
  "fil-ocl",
@@ -167,7 +167,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "serde 1.0.104",
 ]
 
@@ -219,7 +219,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding",
  "byte-tools",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "generic-array",
 ]
 
@@ -265,9 +265,9 @@ checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 
 [[package]]
 name = "byteorder"
-version = "1.3.2"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -275,7 +275,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "either",
  "iovec",
 ]
@@ -362,6 +362,7 @@ version = "0.0.0"
 dependencies = [
  "filecoin-proofs",
  "hex",
+ "storage-proofs",
 ]
 
 [[package]]
@@ -636,7 +637,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44b4c77ad8a724f1ebb882af5d2d7a2ab62f4d63c8e401d40ab0de1d75262ea3"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "ff_derive",
  "rand_core 0.5.1",
 ]
@@ -694,7 +695,7 @@ dependencies = [
  "bellperson",
  "blake2b_simd",
  "blake2s_simd",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "cc",
  "ff",
  "lazy_static 1.4.0",
@@ -724,7 +725,7 @@ dependencies = [
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "chrono",
  "clap",
  "colored",
@@ -917,7 +918,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "bytes",
  "fnv",
  "futures",
@@ -1504,7 +1505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b657ae2c2e72d3ac5c091321f7fa187ee9c2f98d8a0c0ead9f0d26eece544cf"
 dependencies = [
  "blake2b_simd",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "ff",
  "groupy",
  "rand_core 0.5.1",
@@ -2050,7 +2051,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7081ed758ec726a6ed8ee7e92f5d3f6e6f8c3901b1f972e3a4a2f2599fad14f"
 dependencies = [
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "half",
  "serde 1.0.104",
 ]
@@ -2149,7 +2150,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "block-modes",
- "byteorder 1.3.2",
+ "byteorder 1.3.4",
  "clap",
  "colored",
  "config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,7 @@ name = "commp"
 version = "0.0.0"
 dependencies = [
  "filecoin-proofs",
+ "hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "commp"
 version = "0.0.0"
+edition = "2018"
 
 [dependencies]
 filecoin-proofs = { path = "../rust-fil-proofs/filecoin-proofs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2018"
 
 [dependencies]
 filecoin-proofs = { path = "../rust-fil-proofs/filecoin-proofs" }
+storage-proofs = { path = "../rust-fil-proofs/storage-proofs" }
 hex = { version = "0.4.0" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use std::env;
 use std::cmp;
 use std::io;
 use std::convert::TryFrom;
-extern crate filecoin_proofs;
+
 use filecoin_proofs::{ UnpaddedBytesAmount, SectorSize, generate_piece_commitment };
-extern crate hex;
+use hex;
 
 // use a file as an io::Reader but pad out extra length at the end with zeros up
 // to the padded size

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,11 +39,7 @@ impl io::Read for PadReader {
             */
             Ok(cs)
         } else {
-            let frb = self.file.read(buf);
-            if !frb.is_ok() {
-                return Err(frb.unwrap_err());
-            }
-            let cs = frb.unwrap();
+            let cs = self.file.read(buf)?;
             self.pos = self.pos + cs;
             Ok(cs)
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //let commitment = info.commitment;
     //let piece_size = info.size;
 
-    let mut data = Vec::new();
+    // Grow the vector big enough so that it doesn't grow it automatically
+    let mut data = Vec::with_capacity((padded_file_size as f64 * 1.01) as usize);
     let mut temp_piece_file = Cursor::new(&mut data);
     // send the source through the preprocessor, writing output to temp file
     let piece_size =

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,15 @@ use std::env;
 use std::fs::File;
 use std::io;
 
-use filecoin_proofs::{generate_piece_commitment, SectorSize, UnpaddedBytesAmount};
+use filecoin_proofs::constants::DefaultPieceHasher;
+use filecoin_proofs::fr32::write_padded;
+use filecoin_proofs::{
+    generate_piece_commitment, PaddedBytesAmount, SectorSize, UnpaddedBytesAmount,
+};
 use hex;
+use storage_proofs::pieces::generate_piece_commitment_bytes_from_source;
+
+use std::io::{Cursor, Seek, SeekFrom};
 
 // use a file as an io::Reader but pad out extra length at the end with zeros up
 // to the padded size
@@ -58,26 +65,43 @@ fn padded_size(size: u64) -> u64 {
     return u64::from(UnpaddedBytesAmount::from(SectorSize(1 << (logv + 1))));
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = env::args().collect();
     let filename = &args[1];
     let file = File::open(filename).expect("Unable to open file");
     let file_size = file.metadata().unwrap().len();
     let padded_file_size = padded_size(file_size);
-    let pad_reader = PadReader {
+    let mut pad_reader = PadReader {
         file: file,
         fsize: usize::try_from(file_size).unwrap(),
         padsize: usize::try_from(padded_file_size).unwrap(),
         pos: 0,
     };
-    let info = generate_piece_commitment(pad_reader, UnpaddedBytesAmount(padded_file_size))
-        .expect("failed to generate piece commitment");
+
+    //// Old code
+    //let info = generate_piece_commitment(pad_reader, UnpaddedBytesAmount(padded_file_size))
+    //   .expect("failed to generate piece commitment");
+    //let commitment = info.commitment;
+    //let piece_size = info.size;
+
+    let mut data = Vec::new();
+    let mut temp_piece_file = Cursor::new(&mut data);
+    // send the source through the preprocessor, writing output to temp file
+    let piece_size =
+       UnpaddedBytesAmount(write_padded(&mut pad_reader, &mut temp_piece_file)? as u64);
+    temp_piece_file.seek(SeekFrom::Start(0))?;
+    let commitment = generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(
+       &mut temp_piece_file,
+       PaddedBytesAmount::from(piece_size).into(),
+    )?;
 
     print!(
         "{} Size: {:?}, Padded: {:?}, CommP {}\n",
         args[1],
-        info.size,
+        piece_size,
         padded_file_size,
-        hex::encode(info.commitment)
+        hex::encode(commitment)
     );
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,76 +1,87 @@
 // Generate a Filecoin CommP for a file
 // Usage: commp <path to file>
 
-use std::fs::File;
-use std::env;
 use std::cmp;
-use std::io;
 use std::convert::TryFrom;
+use std::env;
+use std::fs::File;
+use std::io;
 
-use filecoin_proofs::{ UnpaddedBytesAmount, SectorSize, generate_piece_commitment };
+use filecoin_proofs::{generate_piece_commitment, SectorSize, UnpaddedBytesAmount};
 use hex;
 
 // use a file as an io::Reader but pad out extra length at the end with zeros up
 // to the padded size
 struct PadReader {
-  file: File,
-  fsize: usize,
-  padsize: usize,
-  pos: usize
+    file: File,
+    fsize: usize,
+    padsize: usize,
+    pos: usize,
 }
 
 impl io::Read for PadReader {
-  fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-    /*
-    if self.pos == self.fsize {
-      print!("reached file size, now padding ...")
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        /*
+        if self.pos == self.fsize {
+          print!("reached file size, now padding ...")
+        }
+        */
+        if self.pos >= self.fsize {
+            for i in 0..buf.len() {
+                buf[i] = 0;
+            }
+            let cs = cmp::min(self.padsize - self.pos, buf.len());
+            self.pos = self.pos + cs;
+            /*
+            if cs < buf.len() {
+              print!("done with file ...")
+            }
+            */
+            Ok(cs)
+        } else {
+            let frb = self.file.read(buf);
+            if !frb.is_ok() {
+                return Err(frb.unwrap_err());
+            }
+            let cs = frb.unwrap();
+            self.pos = self.pos + cs;
+            Ok(cs)
+        }
     }
-    */
-    if self.pos >= self.fsize {
-      for i in 0..buf.len() {
-        buf[i] = 0;
-      }
-      let cs = cmp::min(self.padsize - self.pos, buf.len());
-      self.pos = self.pos + cs;
-      /*
-      if cs < buf.len() {
-        print!("done with file ...")
-      }
-      */
-      Ok(cs)
-    } else {
-      let frb = self.file.read(buf);
-      if !frb.is_ok() {
-        return Err(frb.unwrap_err())
-      }
-      let cs = frb.unwrap();
-      self.pos = self.pos + cs;
-      Ok(cs)
-    }
-  }
 }
 
 // logic partly copied from Lotus' PadReader which is also in go-fil-markets
 // figure out how big this piece will be when padded
-fn padded_size (size: u64) -> u64 {
-  let logv = 64 - size.leading_zeros();
-  let sect_size = (1 as u64) << logv;
-  let bound = u64::from(UnpaddedBytesAmount::from(SectorSize(sect_size)));
-  if size <= bound {
-    return bound
-  }
-  return u64::from(UnpaddedBytesAmount::from(SectorSize(1 << (logv + 1))));
+fn padded_size(size: u64) -> u64 {
+    let logv = 64 - size.leading_zeros();
+    let sect_size = (1 as u64) << logv;
+    let bound = u64::from(UnpaddedBytesAmount::from(SectorSize(sect_size)));
+    if size <= bound {
+        return bound;
+    }
+    return u64::from(UnpaddedBytesAmount::from(SectorSize(1 << (logv + 1))));
 }
 
 fn main() {
-  let args: Vec<String> = env::args().collect();
-  let filename = &args[1];
-  let file = File::open(filename).expect("Unable to open file");
-  let file_size = file.metadata().unwrap().len();
-  let padded_file_size = padded_size(file_size);
-  let pad_reader = PadReader { file: file, fsize: usize::try_from(file_size).unwrap(), padsize: usize::try_from(padded_file_size).unwrap(), pos: 0 };
-  let info = generate_piece_commitment(pad_reader, UnpaddedBytesAmount(padded_file_size))
-    .expect("failed to generate piece commitment");
-  
-  print!("{} Size: {:?}, Padded: {:?}, CommP {}\n", args[1], info.size, padded_file_size, hex::encode(info.commitment));
+    let args: Vec<String> = env::args().collect();
+    let filename = &args[1];
+    let file = File::open(filename).expect("Unable to open file");
+    let file_size = file.metadata().unwrap().len();
+    let padded_file_size = padded_size(file_size);
+    let pad_reader = PadReader {
+        file: file,
+        fsize: usize::try_from(file_size).unwrap(),
+        padsize: usize::try_from(padded_file_size).unwrap(),
+        pos: 0,
+    };
+    let info = generate_piece_commitment(pad_reader, UnpaddedBytesAmount(padded_file_size))
+        .expect("failed to generate piece commitment");
+
+    print!(
+        "{} Size: {:?}, Padded: {:?}, CommP {}\n",
+        args[1],
+        info.size,
+        padded_file_size,
+        hex::encode(info.commitment)
+    );
 }


### PR DESCRIPTION
This code shows how to do things in memory without a temporary file.

The point here is that the `write_padded()` call is still needed. This call is not about doing the padding with zeros, but it is manipulating the data itself. For more information see https://github.com/filecoin-project/rust-fil-proofs/blob/0f9bd279c678a2f41bdad8bf9755a5125654574f/filecoin-proofs/src/fr32.rs.

So this code just creates a huge in-memory vector holding the data which would normally be written to the temporary file.

My guess is (I haven't checked) that the process could probably be streamed, so that you don't need to allocate for the full file size. But that surely would be a major change to the code (and perhaps even not easily possible).

---

The last commit is the actual change, all priory ones were just improvements of the original code.
