### PR TITLE
storage-proofs local / reimplemented version with VecStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,8 +360,10 @@ dependencies = [
 name = "commp"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "filecoin-proofs",
  "hex",
+ "merkletree",
  "storage-proofs",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "716960a18f978640f25101b5cbf1c6f6b0d3192fab36a2d98ca96f0ecbe41010"
+
+[[package]]
 name = "c2-chacha"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +367,7 @@ name = "commp"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytesize",
  "filecoin-proofs",
  "hex",
  "merkletree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2018"
 [dependencies]
 filecoin-proofs = { path = "../rust-fil-proofs/filecoin-proofs" }
 storage-proofs = { path = "../rust-fil-proofs/storage-proofs" }
-hex = { version = "0.4.0" }
+hex = "0.4.0"
+merkletree = "0.14.0"
+anyhow = "1.0.23"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ storage-proofs = { path = "../rust-fil-proofs/storage-proofs" }
 hex = "0.4.0"
 merkletree = "0.14.0"
 anyhow = "1.0.23"
+bytesize = "1.0.0"

--- a/monitor.sh
+++ b/monitor.sh
@@ -13,6 +13,7 @@ TMPDIR=$tmpfs $cmd &
 
 cmdpid=$!
 
+sleep 0.2
 peakmem=0
 peakdisk=0
 while kill -0 $cmdpid >& /dev/null

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use anyhow::ensure;
+use bytesize;
 use hex;
 
 use filecoin_proofs::constants::DefaultPieceHasher;
@@ -165,10 +166,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     print!(
-        "{}\n\tSize: {:?}\n\tPadded: {:?}\n\tCommP {}\n",
+        "{}\n\tSize: {}\n\tPadded Size: {}\n\tPiece Size: {}\n\tCommP {}\n",
         filename,
-        u64::from(piece_size),
-        padded_file_size,
+        bytesize::ByteSize::b(file_size),
+        bytesize::ByteSize::b(padded_file_size),
+        bytesize::ByteSize::b(u64::from(piece_size)),
         hex::encode(commitment)
     );
 


### PR DESCRIPTION
This adds a third method of generating commp by locally reimplememting the storage-proofs code and forcing the use of a memory cache rather than a disk cache.

With this method, the only significant thing it uses in rust-fil-proofs is [fr32](https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/fr32.rs) which does the padding of the piece (adding 2 bits per 254 bits). It reimplements `generate_piece_commitment_bytes_from_source` (complete copypasta) but that is able to call a version of `MerkleTree` (from the [merkletree](https://github.com/filecoin-project/merkle_light/blob/master/src/merkle.rs) library) that uses `VecStore` rather than the `DiskStore` version that's hardwired in to rust-fil-proofs (in [merkle.rs](https://github.com/filecoin-project/rust-fil-proofs/blob/0f9bd279c678a2f41bdad8bf9755a5125654574f/storage-proofs/src/merkle.rs#L22-L23)).

So now, the three methods give us the same result for the 1G file, monitoring disk and memory usage:

**filecoin-proofs** (calling in to `filecoin_proofs::generate_piece_commitment()` to do padding plus commp):

```
	Size: 1007.9 MB
	Padded Size: 1065.4 MB
	Piece Size: 1065.4 MB
	CommP 1232be3a006dfb6e978a5aa4c3da433e78a660c204ea40bbd3fe31ba67c03d33
Took ~13 seconds
Peak disk 3069 Mb
Peak mem 4 Mb
```

**storage-proofs** (calling in to `storage_proofs::generate_piece_commitment_bytes_from_source()` to generate commp after generating the padded version in an array locally, as per #1):

```
	Size: 1007.9 MB
	Padded Size: 1065.4 MB
	Piece Size: 1065.4 MB
	CommP 1232be3a006dfb6e978a5aa4c3da433e78a660c204ea40bbd3fe31ba67c03d33
Took ~7 seconds
Peak disk 2031 Mb
Peak mem 1029 Mb
```

**storage-proofs local** (reimplementing `storage_proofs::generate_piece_commitment_bytes_from_source()` but calling `MerkleTree` with a `VecStore` cache):

```
	Size: 1007.9 MB
	Padded Size: 1065.4 MB
	Piece Size: 1065.4 MB
	CommP 1232be3a006dfb6e978a5aa4c3da433e78a660c204ea40bbd3fe31ba67c03d33
Took ~7 seconds
Peak disk 0 Mb
Peak mem 2995 Mb
```

Keep in mind that this is _just_ for doing these tasks, any more functionality to talk to S3 and manage AWS credentials would be on top of that if this were to go into Lambda, so we're edging right up to the 3,008 Mb limit if it were run there, and this will change with input file size too of course.