### PR TITLE
feat: move binaries source into the `src/bin` directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 name = "commp"
 version = "0.0.0"
 edition = "2018"
-autobins = false
 
 [dependencies]
 filecoin-proofs = { path = "../rust-fil-proofs/filecoin-proofs" }
@@ -19,11 +18,3 @@ log = "^0.4"
 flexi_logger = "0.14.8"
 rusoto_core = "0.42.0"
 rusoto_s3 = "0.42.0"
-
-[[bin]]
-name = "commp"
-path = "src/main.rs"
-
-[[bin]]
-name = "bootstrap"
-path = "src/lambda.rs"

--- a/src/bin/commp.rs
+++ b/src/bin/commp.rs
@@ -2,8 +2,6 @@
 // Usage: commp <path to file> [fp]
 // specify "fp" to run through filecoin_proofs
 
-mod commp;
-
 use std::env;
 use std::fs::File;
 

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -1,5 +1,3 @@
-mod commp;
-
 use std::error::Error;
 use std::str::FromStr;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ use log::info;
 
 use anyhow::{Context, Result};
 
-#[path = "multistore.rs"]
 mod multistore;
 
 type VecStore<E> = merkletree::store::VecStore<E>;


### PR DESCRIPTION
This project is now a library which is used by two binaries named
`commp` and `lambda`.