### PR TITLE
update to latest proofs code, use new fr32 pad_reader, don't use multistore for lambda

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
 dependencies = [
  "memchr",
 ]
@@ -58,15 +58,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
+checksum = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
 
 [[package]]
 name = "arc-swap"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+checksum = "d663a8e9a99154b5fb793032533f6328da35e23aac63d5c152279aa8ba356825"
 
 [[package]]
 name = "arrayref"
@@ -114,9 +114,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4036b9bf40f3cf16aba72a3d65e8a520fc4bafcdc7079aea8f848c58c5b5536"
+checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+checksum = "ca797db0057bae1a7aa2eef3283a874695455cecf08a43bfb8507ee0ebc1ed69"
 dependencies = [
  "cc",
  "libc",
@@ -151,9 +151,9 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "bellperson"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e640126c9941b265bf572dd8f4d3f4c0c109ed9bb92d7991813add6883a3425b"
+checksum = "905883b36765f93e30f0818de0e74dbff61032d126af16fb223b6ce71ef3b615"
 dependencies = [
  "bit-vec",
  "blake2s_simd",
@@ -170,7 +170,7 @@ dependencies = [
  "log",
  "memmap",
  "num_cpus",
- "paired",
+ "paired 0.18.0",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
@@ -184,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 dependencies = [
  "byteorder 1.3.4",
- "serde 1.0.104",
+ "serde 1.0.105",
 ]
 
 [[package]]
@@ -220,6 +220,12 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitintr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba5a5c4df8ac8673f22698f443ef1ce3853d7f22d5a15ebf66b9a7553b173dd"
 
 [[package]]
 name = "bitvec"
@@ -319,15 +325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "c2-chacha"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
-dependencies = [
- "ppv-lite86",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,13 +347,13 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits 0.2.11",
- "serde 1.0.104",
+ "serde 1.0.105",
  "time",
 ]
 
@@ -406,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8815e2ab78f3a59928fc32e141fbeece88320a240e43f47b2fd64ea3a88a5b3d"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 dependencies = [
  "atty",
  "lazy_static 1.4.0",
@@ -430,7 +427,7 @@ dependencies = [
  "num-format",
  "rusoto_core",
  "rusoto_s3",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_derive",
  "serde_json",
  "storage-proofs",
@@ -445,7 +442,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom",
  "rust-ini",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde-hjson",
  "serde_json",
  "toml 0.4.10",
@@ -479,7 +476,7 @@ dependencies = [
  "idna 0.1.5",
  "log",
  "publicsuffix",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_json",
  "time",
  "try_from",
@@ -488,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.6.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -498,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
 name = "cpu-time"
@@ -532,38 +529,41 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue 0.2.1",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 dependencies = [
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cfg-if",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "lazy_static 1.4.0",
+ "maybe-uninit",
  "memoffset",
  "scopeguard 1.1.0",
 ]
@@ -584,7 +584,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
  "cfg-if",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -599,11 +599,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 0.1.7",
+ "autocfg 1.0.0",
  "cfg-if",
  "lazy_static 1.4.0",
 ]
@@ -620,12 +620,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8ce37ad4184ab2ce004c33bf6379185d3b1c95801cab51026bd271bf68eedc"
+checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
 dependencies = [
- "quote 1.0.2",
- "syn 1.0.14",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -709,18 +709,18 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
+checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
 dependencies = [
- "version_check 0.1.5",
+ "version_check 0.9.1",
 ]
 
 [[package]]
 name = "failure"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -728,13 +728,13 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
  "synstructure 0.12.3",
 ]
 
@@ -766,9 +766,9 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits 0.2.11",
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "fil-sapling-crypto"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b353c0d77cecc51c34b08db945063b14b8cbecd138a803bba79dbb8f6bc6e51"
+checksum = "66bff0408599e38b76d779c3bdbbb997ad655acf77a7e5e6d2b902346a616548"
 dependencies = [
  "bellperson",
  "blake2b_simd",
@@ -814,7 +814,7 @@ dependencies = [
  "cc",
  "fff",
  "lazy_static 1.4.0",
- "paired",
+ "paired 0.18.0",
  "rand 0.7.3",
  "rand_core 0.5.1",
 ]
@@ -837,6 +837,7 @@ dependencies = [
  "anyhow",
  "bellperson",
  "bincode",
+ "bitintr",
  "bitvec",
  "blake2b_simd",
  "blake2s_simd",
@@ -857,20 +858,19 @@ dependencies = [
  "merkletree",
  "os_pipe",
  "os_type",
- "paired",
+ "paired 0.18.0",
  "pbr",
  "rand 0.7.3",
  "rand_xorshift 0.2.0",
  "rayon",
  "regex",
  "reqwest",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_cbor",
  "serde_json",
  "storage-proofs",
  "tar",
  "tee",
- "tempfile",
  "typenum",
 ]
 
@@ -888,9 +888,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
+checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d6a47d6e4b8559729f58287efa8e6f767e603c068fea7a5e4d9f1cebe2bebb"
+checksum = "f36b5f248235f45773d4944f555f83ea61fe07b18b561ccf99d7483d7381e54d"
 
 [[package]]
 name = "hashbrown"
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2c55f143919fbc0bc77e427fe2d74cf23786d7c1875666f2fde3ac3c659bb67"
+checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
@@ -1081,6 +1081,16 @@ name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
+name = "hkdf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1247,7 +1257,7 @@ dependencies = [
  "failure",
  "lambda_runtime_core",
  "log",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_derive",
  "serde_json",
  "tokio",
@@ -1264,7 +1274,7 @@ dependencies = [
  "hyper",
  "lambda_runtime_errors",
  "log",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_derive",
  "serde_json",
  "tokio",
@@ -1328,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 
 [[package]]
 name = "libloading"
@@ -1396,9 +1406,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53445de381a1f436797497c61d851644d0e8e88e6140f22872ad33a704933978"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -1412,16 +1422,18 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
 dependencies = [
- "rustc_version 0.2.3",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
 name = "merkletree"
-version = "0.16.1"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1f477e2eb5ab293e59b08869e3fd86b6eaf8e7f61b3bfb79549fb2a1632e08"
 dependencies = [
  "anyhow",
  "arrayref",
@@ -1430,7 +1442,7 @@ dependencies = [
  "positioned-io",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.104",
+ "serde 1.0.105",
  "tempdir",
  "tempfile",
  "typenum",
@@ -1444,9 +1456,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "mime_guess"
-version = "2.0.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
@@ -1527,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static 1.4.0",
  "libc",
@@ -1545,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "neptune"
-version = "0.4.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0ad2cad3bf4fca5e73c35dfddcaf2c89230667064a879097fe45d14686bf58"
+checksum = "65fb2186a04d0ecb439f9580cefe97f6bb13fec4e60b75ace00465c55b4106ee"
 dependencies = [
  "bellperson",
  "blake2s_simd",
@@ -1555,7 +1567,7 @@ dependencies = [
  "fff",
  "generic-array 0.13.2",
  "lazy_static 1.4.0",
- "paired",
+ "paired 0.17.0",
  "rand_xorshift 0.2.0",
 ]
 
@@ -1736,6 +1748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,7 +1841,22 @@ dependencies = [
  "fff",
  "groupy",
  "rand_core 0.5.1",
- "serde 1.0.104",
+]
+
+[[package]]
+name = "paired"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8e00a5c3f72cfb17fc051c179470610a3888e463b66ba753ea22fee3972d72"
+dependencies = [
+ "blake2b_simd",
+ "byteorder 1.3.4",
+ "fff",
+ "groupy",
+ "hkdf",
+ "rand_core 0.5.1",
+ "serde 1.0.105",
+ "sha2ni",
 ]
 
 [[package]]
@@ -1929,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -1966,11 +1999,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.8",
+ "proc-macro2 1.0.9",
 ]
 
 [[package]]
@@ -2023,7 +2056,7 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
 ]
@@ -2040,11 +2073,11 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
- "c2-chacha",
+ "ppv-lite86",
  "rand_core 0.5.1",
 ]
 
@@ -2153,6 +2186,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
+dependencies = [
+ "bitflags",
+ "cc",
+ "rustc_version 0.2.3",
+]
+
+[[package]]
 name = "rayon"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2171,7 +2215,7 @@ checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue 0.2.1",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "lazy_static 1.4.0",
  "num_cpus",
 ]
@@ -2213,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322cf97724bea3ee221b78fe25ac9c46114ebb51747ad5babd51a2fc6a8235a8"
+checksum = "8900ebc1363efa7ea1c399ccc32daed870b4002651e0bed86e72d501ebbe0048"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2225,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
 name = "remove_dir_all"
@@ -2258,7 +2302,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "native-tls",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_json",
  "serde_urlencoded",
  "time",
@@ -2289,7 +2333,7 @@ dependencies = [
  "rusoto_credential",
  "rusoto_signature",
  "rustc_version 0.2.3",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_derive",
  "serde_json",
  "time",
@@ -2310,7 +2354,7 @@ dependencies = [
  "hyper",
  "lazy_static 1.4.0",
  "regex",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_derive",
  "serde_json",
  "shlex",
@@ -2348,8 +2392,8 @@ dependencies = [
  "percent-encoding 2.1.0",
  "rusoto_credential",
  "rustc_version 0.2.3",
- "serde 1.0.104",
- "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.105",
+ "sha2",
  "time",
  "tokio",
 ]
@@ -2363,7 +2407,7 @@ dependencies = [
  "base64 0.11.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -2404,9 +2448,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+checksum = "535622e6be132bccd223f4bb2b8ac8d53cda3c7a6394944d3b2b33fb974f9d76"
 
 [[package]]
 name = "schannel"
@@ -2432,23 +2476,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
+checksum = "97bbedbe81904398b6ebb054b3e912f99d55807125790f3198ac990d98def5b0"
 dependencies = [
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
- "libc",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
+checksum = "06fd2f23e31ef68dd2328cc383bd493142e46107a3a0e24f7d734e3f3b80fe4c"
 dependencies = [
  "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2480,9 +2525,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+checksum = "e707fbbf255b8fc8c3b99abb91e7257a622caeb20a9818cbadbeeede4e0932ff"
 dependencies = [
  "serde_derive",
 ]
@@ -2508,18 +2553,18 @@ checksum = "f7081ed758ec726a6ed8ee7e92f5d3f6e6f8c3901b1f972e3a4a2f2599fad14f"
 dependencies = [
  "byteorder 1.3.4",
  "half",
- "serde 1.0.104",
+ "serde 1.0.105",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -2530,7 +2575,7 @@ checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 dependencies = [
  "itoa",
  "ryu",
- "serde 1.0.104",
+ "serde 1.0.105",
 ]
 
 [[package]]
@@ -2550,20 +2595,8 @@ checksum = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 dependencies = [
  "dtoa",
  "itoa",
- "serde 1.0.104",
+ "serde 1.0.105",
  "url 1.7.2",
-]
-
-[[package]]
-name = "sha2"
-version = "0.8.1"
-source = "git+https://github.com/dignifiedquire/hashes?branch=sha2-intrinsics#cdcbc41d7f75e72928b1d2a81da8e987dc508fea"
-dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "lazy_static 1.4.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -2576,6 +2609,32 @@ dependencies = [
  "digest",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2ni"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229896851bde067cb56bfb6cd669d9904c3441245bc32172f33d9a895ddef27d"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "lazy_static 1.4.0",
+ "opaque-debug",
+ "raw-cpuid",
+]
+
+[[package]]
+name = "sha2raw"
+version = "0.1.0"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "lazy_static 1.4.0",
+ "opaque-debug",
+ "raw-cpuid",
 ]
 
 [[package]]
@@ -2667,16 +2726,18 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-traits 0.2.11",
  "num_cpus",
- "paired",
+ "once_cell",
+ "paired 0.18.0",
  "pbr",
  "pretty_assertions",
  "rand 0.7.3",
- "rand_chacha 0.2.1",
+ "rand_chacha 0.2.2",
  "rand_xorshift 0.2.0",
  "rayon",
- "serde 1.0.104",
+ "serde 1.0.105",
  "serde_json",
- "sha2 0.8.1 (git+https://github.com/dignifiedquire/hashes?branch=sha2-intrinsics)",
+ "sha2ni",
+ "sha2raw",
  "tempdir",
  "tempfile",
  "thiserror",
@@ -2717,12 +2778,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
  "unicode-xid 0.2.0",
 ]
 
@@ -2744,9 +2805,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
  "unicode-xid 0.2.0",
 ]
 
@@ -2837,9 +2898,9 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
 dependencies = [
- "proc-macro2 1.0.8",
- "quote 1.0.2",
- "syn 1.0.14",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -2924,7 +2985,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "futures",
 ]
 
@@ -2975,7 +3036,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "futures",
  "lazy_static 1.4.0",
  "log",
@@ -3037,7 +3098,7 @@ checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue 0.2.1",
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "futures",
  "lazy_static 1.4.0",
  "log",
@@ -3052,7 +3113,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils 0.7.0",
+ "crossbeam-utils 0.7.2",
  "futures",
  "slab",
  "tokio-executor",
@@ -3097,7 +3158,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 dependencies = [
- "serde 1.0.104",
+ "serde 1.0.105",
 ]
 
 [[package]]
@@ -3106,7 +3167,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
- "serde 1.0.104",
+ "serde 1.0.105",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2018"
 filecoin-proofs = { path = "../rust-fil-proofs/filecoin-proofs" }
 storage-proofs = { path = "../rust-fil-proofs/storage-proofs" }
 hex = "0.4"
-merkletree = { path = "../merkle_light" }
+# merkletree = { path = "../merkle_light" }
+merkletree = "0.16.4"
 anyhow = "1.0"
 num-format = { version = "0.4", features = ["with-system-locale"] }
 lambda_runtime = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 filecoin-proofs = { path = "../rust-fil-proofs/filecoin-proofs" }
 storage-proofs = { path = "../rust-fil-proofs/storage-proofs" }
 hex = "0.4"
-# merkletree = { path = "../merkle_light" }
 merkletree = "0.16.4"
 anyhow = "1.0"
 num-format = { version = "0.4", features = ["with-system-locale"] }

--- a/src/bin/commp.rs
+++ b/src/bin/commp.rs
@@ -5,22 +5,22 @@
 use std::env;
 use std::fs::File;
 
-use num_format::{SystemLocale, Buffer};
 use flexi_logger::Logger;
 use hex;
+use num_format::{Buffer, SystemLocale};
 
 fn usage() {
     print!("Usage: commp [-fp|-sp|-spl] <file>\n");
 }
 
 // srsly? all this just to print a size nicely with comma grouping?
-fn to_mb (size : u64) -> String {
-  let locale = SystemLocale::default().unwrap();
-  let r = (((size as f64) / 1024.0 / 1024.0) * 100.0).round() / 100.0;
-  let mut buf = Buffer::default();
-  buf.write_formatted(&(r.floor() as i64), &locale);
-  let rem = (r.fract() * 100.0).round() as i64;
-  return (buf.as_str().to_owned() + "." + &rem.to_string() + " Mb").to_string();
+fn to_mb(size: u64) -> String {
+    let locale = SystemLocale::default().unwrap();
+    let r = (((size as f64) / 1024.0 / 1024.0) * 100.0).round() / 100.0;
+    let mut buf = Buffer::default();
+    buf.write_formatted(&(r.floor() as i64), &locale);
+    let rem = (r.fract() * 100.0).round() as i64;
+    return (buf.as_str().to_owned() + "." + &rem.to_string() + " Mb").to_string();
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -39,9 +39,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if &args[1] == "-fp" {
         commp = commp::generate_commp_filecoin_proofs(&mut file, file_size).unwrap();
-    } else if &args[1] == "-sp" {
+    }
+    /* else if &args[1] == "-sp" {
         commp = commp::generate_commp_storage_proofs(&mut file, file_size).unwrap();
-    } else if &args[1] == "-spl" {
+    } */
+    else if &args[1] == "-spl" {
         commp = commp::generate_commp_storage_proofs_mem(&mut file, file_size, false).unwrap();
     } else if &args[1] == "-splm" {
         commp = commp::generate_commp_storage_proofs_mem(&mut file, file_size, true).unwrap();

--- a/src/bin/commp.rs
+++ b/src/bin/commp.rs
@@ -39,11 +39,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if &args[1] == "-fp" {
         commp = commp::generate_commp_filecoin_proofs(&mut file, file_size).unwrap();
-    }
-    /* else if &args[1] == "-sp" {
+    } else if &args[1] == "-sp" {
         commp = commp::generate_commp_storage_proofs(&mut file, file_size).unwrap();
-    } */
-    else if &args[1] == "-spl" {
+    } else if &args[1] == "-spl" {
         commp = commp::generate_commp_storage_proofs_mem(&mut file, file_size, false).unwrap();
     } else if &args[1] == "-splm" {
         commp = commp::generate_commp_storage_proofs_mem(&mut file, file_size, true).unwrap();

--- a/src/bin/lambda.rs
+++ b/src/bin/lambda.rs
@@ -69,7 +69,7 @@ fn commp_handler(request: CommPRequest, _c: Context) -> Result<CommPResponse, Ha
 
     let mut stream = result.body.unwrap().into_blocking_read();
 
-    let commp = commp::generate_commp_storage_proofs_mem(&mut stream, size, true).unwrap();
+    let commp = commp::generate_commp_storage_proofs_mem(&mut stream, size, false).unwrap();
 
     Ok(CommPResponse {
         region: request.region,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::io::{BufReader, Read};
 
 use filecoin_proofs::constants::DefaultPieceHasher;
-use filecoin_proofs::pad_reader::PadReader;
+use filecoin_proofs::fr32_reader::Fr32Reader;
 use filecoin_proofs::{
     generate_piece_commitment, PaddedBytesAmount, SectorSize, UnpaddedBytesAmount,
 };
@@ -73,7 +73,7 @@ fn piece_size(size: u64, next: bool) -> u64 {
     1u64 << (64 - size.leading_zeros() + if next { 1 } else { 0 })
 }
 
-// logic partly copied from Lotus' PadReader which is also in go-fil-markets
+// logic partly copied from Lotus' Fr32Reader which is also in go-fil-markets
 // figure out how big this piece will be when padded
 fn padded_size(size: u64) -> u64 {
     let bound = u64::from(UnpaddedBytesAmount::from(SectorSize(piece_size(
@@ -161,7 +161,6 @@ fn base2_padded<R: Sized + io::Read>(inp: &mut R, size: u64) -> Base2PadReader<&
  * which would be the more "correct" way to call in because most things
  * are done for you.
  */
-#[allow(dead_code)]
 pub fn generate_commp_filecoin_proofs<R: Sized + io::Read>(
     inp: &mut R,
     size: u64,
@@ -189,7 +188,6 @@ pub fn generate_commp_filecoin_proofs<R: Sized + io::Read>(
  * ourselves but end up in the same place, so this is just a plain
  * reimplementation of the filecoin_proofs method above.
  */
-#[allow(dead_code)]
 pub fn generate_commp_storage_proofs<R: Sized + io::Read>(
     inp: &mut R,
     size: u64,
@@ -200,7 +198,7 @@ pub fn generate_commp_storage_proofs<R: Sized + io::Read>(
 
     let uba = UnpaddedBytesAmount(padded_size as u64);
 
-    let mut pad_reader = PadReader::new(base2_pad_reader);
+    let mut pad_reader = Fr32Reader::new(base2_pad_reader);
 
     // storage_proofs
     let commitment = generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(
@@ -242,7 +240,7 @@ pub fn generate_commp_storage_proofs_mem<R: Sized + io::Read>(
 
     let uba = UnpaddedBytesAmount(padded_size as u64);
 
-    let mut pad_reader = PadReader::new(base2_pad_reader);
+    let mut pad_reader = Fr32Reader::new(base2_pad_reader);
 
     let commitment = if multistore {
         generate_piece_commitment_bytes_from_source_with_multistore::<DefaultPieceHasher>(

--- a/src/multistore.rs
+++ b/src/multistore.rs
@@ -25,7 +25,12 @@ impl<E: Element> Store<E> for MultiStore<E> {
     fn new(size: usize) -> Result<Self> {
         Ok(MultiStore {
             disk: DiskStore::new(DISK_MAX).unwrap(),
-            mem: VecStore::new(if size < DISK_MAX { size } else { size - DISK_MAX }).unwrap(),
+            mem: VecStore::new(if size < DISK_MAX {
+                size
+            } else {
+                size - DISK_MAX
+            })
+            .unwrap(),
         })
     }
 


### PR DESCRIPTION
Avoids the need to use the custom multistore which I don't have high confidence in, uses the streaming fr32 padding reader which shaves off ~1G from a ~<=1G input. Gets the Lambda version closer to rust-fil-proofs with less jank between. We're still injecting a `VecStore` backed `MerkleTree` which rust-fil-proofs doesn't use but the reimplementation of that is fairly trivial and mostly copypasta.